### PR TITLE
optimize: modify files about deploy

### DIFF
--- a/config/mysql.yaml
+++ b/config/mysql.yaml
@@ -1,5 +1,5 @@
 host: "127.0.0.1"
-port: 3306
+port: 3307
 database: "test"
 username: "root"
 password: "root"

--- a/deploy/env.yml
+++ b/deploy/env.yml
@@ -6,6 +6,12 @@ volumes:
     zoo_vol:
     kafka_vol:
     hb_vol:
+    hadoop_namenode:
+    hadoop_datanode:
+    hadoop_historyserver:
+    hbase_data:
+    hbase_zookeeper_data:
+    prometheus_data:
 
 networks:
     total:
@@ -23,7 +29,7 @@ services:
         ports:
             - "6379:6379"
         restart: always
-    
+
     mysql:
         image: mysql:8.0
         env_file:
@@ -34,20 +40,20 @@ services:
             - mysql_vol:/var/lib/mysql:rw
             - ./my.cnf:/etc/mysql/my.cnf
         ports:
-            - "3306:3306"
+            - "3307:3307"
         restart: always
 
-    zookeeper:
-        image: wurstmeister/zookeeper:3.4.6
-        networks:
-            - total
-        volumes:
-            - zoo_vol:/opt/zookeeper-3.4.6/data
-        container_name: zoo
-        ports:
-            - "2181:2181"
-            - "2182:2182"
-        restart: always
+    # zookeeper:
+    #     image: wurstmeister/zookeeper:3.4.6
+    #     networks:
+    #         - total
+    #     volumes:
+    #         - zoo_vol:/opt/zookeeper-3.4.6/data
+    #     container_name: zookeeper
+    #     ports:
+    #         - "2180:2181"
+    #         - "2182:2182"
+    #     restart: always
 
     kafka:
         image: wurstmeister/kafka
@@ -55,7 +61,7 @@ services:
         networks:
             - total
         depends_on:
-            - zookeeper
+            - hbase
         ports:
             - "9092:9092"
         volumes:
@@ -64,10 +70,10 @@ services:
             - KAFKA_LISTENERS=PLAINTEXT://kafka:9092
             - KAFKA_ADVERTISED_NAME=kafka
             - KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://kafka:9092
-            - KAFKA_ZOOKEEPER_CONNECT=zookeeper:2181
+            - KAFKA_ZOOKEEPER_CONNECT=hbase:2181
             - KAFKA_HEAP_OPTS=-Xmx512M -Xms16M
         restart: always
-    
+
     kafka-manager:
         image: sheepkiller/kafka-manager
         networks:
@@ -75,12 +81,12 @@ services:
         ports:
             - "9099:9000"
         environment:
-            - ZK_HOSTS=zookeeper:2181
+            - ZK_HOSTS=hbase:2181
         depends_on:
-            - zookeeper
+            - hbase
             - kafka
         restart: always
-    
+
     mongo:
         image: mongo:6.0.3
         networks:
@@ -93,23 +99,31 @@ services:
         restart: always
 
     hbase:
-        image: harisekhon/hbase:2.1
+        # image: harisekhon/hbase:2.1
+        build: ./hbase
         container_name: hbase
+        hostname: master
         networks:
             - total
         ports:
             - "16000:16000"
             - "16010:16010"
+            - "16020:16020"
             - "16030:16030"
             - "16201:16201"
             - "9090:9090"
             - "9095:9095"
-            - "8080:8080"
-            - "8085:8085"
-            - "2180:2181"
+            - "2181:2181"
         volumes:
-            - hb_vol:/hbase-data
-    
+            # - hb_vol:/hbase-data
+            - ./hbase-data:/hbase-data
+            # - ./hbase-conf:/hbase-2.1.3/conf
+            # - ./hbase-conf:/hbase/conf
+            - ./hbase-zoo-data:/zookeeper-data
+        environment:
+            - HBASE_CONF_hbase_cluster_distributed=false
+        restart: always
+
     etcd:
         image: quay.io/coreos/etcd
         container_name: etcd
@@ -120,7 +134,7 @@ services:
             - "2379:2379"
             - "2380:2380"
         restart: always
-    
+
     es:
         image: elasticsearch:7.13.1
         container_name: es
@@ -136,7 +150,23 @@ services:
             - "9200:9200"
         restart: always
 
-    jaeger:
+    otel-collector:
+        image: otel/opentelemetry-collector-contrib-dev:latest
+        command: [ "--config=/etc/otel-collector-config.yml", "${OTELCOL_ARGS}" ]
+        volumes:
+            - ./otel-collector-config.yml:/etc/otel-collector-config.yml
+        ports:
+            - "1888:1888"   # pprof extension
+            - "8888:8888"   # Prometheus metrics exposed by the collector
+            - "8889:8889"   # Prometheus exporter metrics
+            - "13133:13133" # health_check extension
+            - "4317:4317"   # OTLP gRPC receiver
+            - "55670:55679" # zpages extension
+        depends_on:
+            - jaeger-all-in-one
+
+    jaeger-all-in-one:
+        platform: linux/x86_64
         image: rancher/jaegertracing-all-in-one:1.20.0
         container_name: jaeger
         networks:
@@ -155,10 +185,36 @@ services:
             - "6832:6832/udp"
             - "5778:5778"
             - "16686:16686"
-            - "4317:4317"
             - "4318:4318"
             - "14250:14250"
             - "14268:14268"
             - "14269:14269"
             - "9411:9411"
         restart: always
+
+    victoriametrics:
+        container_name: victoriametrics
+        image: victoriametrics/victoria-metrics
+        ports:
+            - "8428:8428"
+            - "8089:8089"
+            - "8089:8089/udp"
+            - "2003:2003"
+            - "2003:2003/udp"
+            - "4242:4242"
+        command:
+            - '--storageDataPath=/storage'
+            - '--graphiteListenAddr=:2003'
+            - '--opentsdbListenAddr=:4242'
+            - '--httpListenAddr=:8428'
+            - '--influxListenAddr=:8089'
+        restart: always
+
+    grafana:
+        image: grafana/grafana:latest
+        environment:
+            - GF_AUTH_ANONYMOUS_ENABLED=true
+            - GF_AUTH_ANONYMOUS_ORG_ROLE=Admin
+            - GF_AUTH_DISABLE_LOGIN_FORM=true
+        ports:
+            - "3000:3000"

--- a/deploy/hbase/Dockerfile
+++ b/deploy/hbase/Dockerfile
@@ -1,0 +1,9 @@
+FROM harisekhon/hbase:2.1
+
+COPY hbase-site.xml /hbase-2.1.3/conf/
+
+COPY hbase-site.xml /hbase/conf/
+
+RUN chmod 777 /hbase-data
+
+ENTRYPOINT [ "./entrypoint.sh" ]

--- a/deploy/hbase/hbase-site.xml
+++ b/deploy/hbase/hbase-site.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<configuration>
+    <property>
+        <name>hbase.cluster.distributed</name>
+        <value>true</value>
+    </property>
+    <property>
+        <name>hbase.rootdir</name>
+        <value>/hbase-data</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.quorum</name>
+        <value>localhost:2181</value>
+    </property>
+    <property>
+        <name>hbase.zookeeper.property.dataDir</name>
+        <value>/zookeeper-data</value>
+    </property>
+    <!-- <property>
+      <name>zookeeper.znode.parent</name>
+      <value>/hbase</value>
+    </property> -->
+</configuration>

--- a/deploy/my.cnf
+++ b/deploy/my.cnf
@@ -5,7 +5,7 @@ character-set-server=utf8
 secure-file-priv=NULL # mysql 8 新增这行配置
 default-authentication-plugin=mysql_native_password  # mysql 8 新增这行配置
 
-port            = 3306 # 端口与docker-compose里映射端口保持一致
+port            = 3307 # 端口与docker-compose里映射端口保持一致
 #bind-address= localhost #一定要注释掉，mysql所在容器和django所在容器不同IP
 
 basedir         = /usr
@@ -16,7 +16,7 @@ socket          = /var/run/mysqld/mysqld.sock
 skip-name-resolve  # 这个参数是禁止域名解析的，远程访问推荐开启skip_name_resolve。
 
 [client]
-port = 3306
+port = 3307
 default-character-set=utf8
 
 [mysql]

--- a/deploy/otel-collector-config.yml
+++ b/deploy/otel-collector-config.yml
@@ -1,0 +1,37 @@
+receivers:
+  otlp:
+    protocols:
+      grpc:
+
+exporters:
+  prometheusremotewrite:
+    endpoint: "http://victoriametrics:8428/api/v1/write"
+
+  logging:
+
+  jaeger:
+    endpoint: jaeger-all-in-one:14250
+    tls:
+      insecure: true
+
+processors:
+  batch:
+
+extensions:
+  health_check:
+  pprof:
+    endpoint: :1888
+  zpages:
+    endpoint: :55679
+
+service:
+  extensions: [ pprof, zpages, health_check ]
+  pipelines:
+    traces:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ logging, jaeger ]
+    metrics:
+      receivers: [ otlp ]
+      processors: [ batch ]
+      exporters: [ logging, prometheusremotewrite ]

--- a/documents/pkgs/grafana.md
+++ b/documents/pkgs/grafana.md
@@ -1,0 +1,8 @@
+## Grafana 监控平台
+
+- 使用 VM 替换 Prometheus
+  https://zyun.360.cn/blog/?p=1536
+- Grafana 数据源 URL 配置问题
+  https://blog.csdn.net/qq_38366063/article/details/128570644
+- DashBoard 展示模板的配置
+  https://blog.csdn.net/ll535299/article/details/127534678


### PR DESCRIPTION
en: modify files about deploy, add tracing (optl) and monitoring related services (vm), use vm to replace prometheus, replace mysql interface with 3307
zh: 修改部署相关的配置文件，增加链路追踪（optl）/监控相关服务（vm），使用 vm 替换 prometheus，mysql 接口替换为 3307