### PR TITLE
增加模块拒绝指定模块调用的中间件，防止循环调用

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 DouTok is a backend for TikTok client based on Kitex and Hertz.
 
+![Hertz](https://img.shields.io/static/v1?label=Golang&message=1.18&color=brightgreen&style=plastic&logo=go) ![Hertz](https://img.shields.io/static/v1?label=Hertz&message=using&color=green&style=plastic&logo=go) ![Hertz](https://img.shields.io/static/v1?label=Kitex&message=using&color=yellowgreen&style=plastic&logo=go) ![Hertz](https://img.shields.io/static/v1?label=gorm/gen&message=using&color=yellow&style=plastic&logo=etcd) ![Hertz](https://img.shields.io/static/v1?label=etcd&message=3.4&color=orange&style=plastic&logo=etcd) ![Hertz](https://img.shields.io/static/v1?label=MySQL&message=8.0&color=red&style=plastic&logo=mysql) ![Hertz](https://img.shields.io/static/v1?label=Redis&message=7.0&color=blue&style=plastic&logo=redis) ![Hertz](https://img.shields.io/static/v1?label=HBase&message=2.1.3&color=blueviolet&style=plastic&logo=ApacheHadoop) ![Hertz](https://img.shields.io/static/v1?label=kafka&message=Tencent&color=ff69b4&style=plastic&logo=ApacheKafka)
+
+## Quick Start
+
+1. Deploy dependencies
+   Deploy some dependencies such as MySQL, Redis etc. Run them by using `docker-compose` with `.yml` files in `./deploy` or deploy them by yourself.
+
+   ```sh
+   docker-compose -f ./deploy/env.yml up -d
+   ```
+
+2. Update config files
+
+   There's a elegent way to run applications in this repo which is using `docker-compose`. So update config files in `./config_docker_compose` if you use `docker-comopse`. If you don't want to run them in this way, you must update config files in `./config` for ensuring them working.
+
+3. Run applications by using `docker-compose`
+   Everything is ready now, ensure that there's a `docker-compose.yml` in the root directory and run this command in terminal
+
+   ```sh
+   docker-compose up -d
+   ```
+
 ## Architecture
 
 ### Technology Architecture
@@ -41,23 +63,102 @@ DouTok is a backend for TikTok client based on Kitex and Hertz.
 | /douyin/message/chat/           | 聊天记录   | 读    |              | 存储优化，缓存优化 |
 | /douyin/message/action/         | 消息操作   | 写    |              | 延迟处理           |
 
-## Quick Start
+## CI/CD
 
-1. env
+- Build docker images by using github actions
+- Push docker images to private repo created with Aliyun by using github actions
+- DOING: Try to run applications with k8s automatically
 
-```shell
-docker-compose -f pro.yml up -d
+## Directories
+
+```tree
+.
+├── applications    // 模块逻辑目录
+│   ├── api    // api模块逻辑实现                        
+│   │   ├── biz    // api模块主要逻辑实现
+│   │   │   ├── handler
+│   │   │   │   ├── api
+│   │   │   │   ├── pack.go
+│   │   │   │   └── ping.go
+│   │   │   ├── model
+│   │   │   │   └── api
+│   │   │   └── router
+│   │   │       ├── api
+│   │   │       └── register.go
+│   │   ├── chat
+│   │   ├── initialize
+│   │   │   ├── init_hertz.go
+│   │   │   ├── jwt.go
+│   │   │   ├── redis.go
+│   │   │   ├── rpc
+│   │   │   └── viper.go
+│   │   ├── main.go
+│   │   ├── Makefile
+│   │   ├── router_gen.go
+│   │   └── router.go
+│   ├── comment    // comment模块逻辑实现
+│   │   ├── build.sh
+│   │   ├── dal    // 数据层
+│   │   │   ├── gen.go    // gorm/gen生成代码
+│   │   │   ├── migrate    // gorm自动迁移
+│   │   │   │   └── main.go
+│   │   │   ├── model    // model层
+│   │   │   └── query    // gorm/gen生成结果
+│   │   │       ├── comment_counts.gen.go
+│   │   │       ├── comments.gen.go
+│   │   │       ├── gen.go
+│   │   │       └── var.go
+│   │   ├── handler    // RPC服务的接口入口
+│   │   ├── main.go    // 模块入口
+│   │   ├── Makefile
+│   │   ├── misc    // 模块所需的一些简单零散逻辑
+│   │   ├── pack    // 将service层提供的数据查询结果包装成接口的返回消息
+│   │   ├── rpc    // 初始化调用其他微服务
+│   │   ├── script
+│   │   ├── service // 数据查询
+│   ├── favorite // favorite模块
+│   ├── feed    // feed模块
+│   ├── message // message模块
+│   ├── publish // publish模块
+│   ├── relation // relation模块
+│   └── user // user模块
+├── config    // 项目所需要的配置文件
+├── deploy    // 项目所需的环境部署
+├── documents    // 相关文档
+├── go.mod
+├── go.sum
+├── kitex_gen    // Kitex生成的代码
+│   ├── comment
+│   ├── favorite
+│   ├── feed
+│   ├── message
+│   ├── publish
+│   ├── relation
+│   └── user
+├── pkg    // 项目所依赖的一些公共包
+│   ├── constants    // 常量包
+│   ├── dlog    // 日志包
+│   ├── dtviper    // 配置包
+│   ├── errno    // 错误码包
+│   ├── hbaseHandle    // HBase操作包
+│   ├── initHelper    // 初始化服务助手
+│   ├── kafka    // Kafka操作包
+│   ├── middleware    // 中间建
+│   ├── misc    // 一些零散逻辑
+│   ├── mock    // Mock测试包
+│   │   ├── comment
+│   │   ├── favorite
+│   │   ├── feed
+│   │   ├── message
+│   │   ├── publish
+│   │   ├── relation
+│   │   └── user
+│   ├── mysqlIniter    // MySQL操作包
+│   ├── ossHandle    // OSS操作包
+│   ├── redisHandle    // Redis操作包
+│   ├── safeMap    // 线程安全的Map
+│   └── utils    // 其他组件
+├── proto    // 基于Protobuf3完成的IDL
+├── README.md
+└── scripts
 ```
-
-2. hostname
-
-```shell
-append [hbase_addr hb-master] in /etc/hosts
-```
-
-3. run each service
-
-```shell
-relation/message/feed/publish/favorite/user/comment/api
-```
-

--- a/applications/api/initialize/init_hertz.go
+++ b/applications/api/initialize/init_hertz.go
@@ -83,6 +83,7 @@ func (d *Duration) UnmarshalJSON(b []byte) error {
 func Init() {
 	InitViper()
 	rpc.InitRPC()
+	rpc.InitLogHandle()
 	InitJwt()
 	InitRedisClient()
 }

--- a/applications/api/initialize/rpc/init.go
+++ b/applications/api/initialize/rpc/init.go
@@ -1,8 +1,11 @@
 package rpc
 
 import (
+	"github.com/TremblingV5/DouTok/pkg/LogBuilder"
 	"github.com/TremblingV5/DouTok/pkg/dtviper"
 )
+
+var logHandle *LogBuilder.Logger
 
 // InitRPC init rpc client
 func InitRPC() {
@@ -26,4 +29,10 @@ func InitRPC() {
 
 	MessageConfig := dtviper.ConfigInit("DOUTOK_MESSAGE", "message")
 	initMessageRpc(&MessageConfig)
+}
+
+func InitLogHandle() {
+	config := dtviper.ConfigInit("DOUTOK_LOG", "log")
+	l := LogBuilder.NewByViper(&config)
+	logHandle = l
 }

--- a/applications/api/initialize/rpc/user.go
+++ b/applications/api/initialize/rpc/user.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"github.com/TremblingV5/DouTok/kitex_gen/user"
 	"github.com/TremblingV5/DouTok/kitex_gen/user/userservice"
+	"github.com/TremblingV5/DouTok/pkg/LogBuilder"
 	"github.com/TremblingV5/DouTok/pkg/dtviper"
 	"github.com/TremblingV5/DouTok/pkg/errno"
 	"github.com/TremblingV5/DouTok/pkg/middleware"
@@ -67,11 +68,27 @@ func Register(ctx context.Context, userClient userservice.Client, req *user.Douy
 
 // 传递 登录操作 的上下文, 并获取 RPC Server 端的响应.
 func Login(ctx context.Context, userClient userservice.Client, req *user.DouyinUserLoginRequest) (int64, error) {
+	log := LogBuilder.InitLogBuilder("info", "RPC request success")
+	defer log.Write(logHandle)
+
+	log.Collect("username", req.Username)
+
 	resp, err := userClient.Login(ctx, req)
+	if resp != nil {
+		log.Collect("user_id", fmt.Sprint(resp.UserId))
+	}
+
 	if err != nil {
+		log.SetLogType("error")
+		log.SetMessage("RPC request defeat")
+		log.Collect("ErrorInfo", err.Error())
 		return 0, err
 	}
 	if resp.StatusCode != 0 {
+		log.SetLogType("warn")
+		log.SetMessage("RPC request success with error number except success")
+		log.Collect("ErrorNo", fmt.Sprint(resp.StatusCode))
+		log.Collect("ErrorMsg", resp.StatusMsg)
 		return 0, errno.NewErrNo(int(resp.StatusCode), resp.StatusMsg)
 	}
 	return resp.UserId, nil

--- a/config/api.yaml
+++ b/config/api.yaml
@@ -7,7 +7,7 @@ JWT:
 
 Etcd:
   Enable: true
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -35,7 +35,7 @@ Client:
     - "192.168.1.1"
 
 Redis:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 6379
   Password: "root"
   DataBases:

--- a/config/comment.yaml
+++ b/config/comment.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -22,7 +22,7 @@ Client:
     - "192.168.1.1"
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"
@@ -38,7 +38,7 @@ HBase:
   Host: "139.9.80.79"
 
 Redis:
-  Dest: "47.115.230.248:6379"
+  Dest: "127.0.0.1:6379"
   Password: "root"
   ComCntCache:
     Num: 8

--- a/config/favorite.yaml
+++ b/config/favorite.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -25,7 +25,7 @@ Snowflake:
   Node: 602
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"
@@ -35,7 +35,7 @@ MySQL:
   loc: "Local"
 
 Redis:
-  Dest: "47.115.230.248:6379"
+  Dest: "127.0.0.1:6379"
   Password: "root"
   FavCache:
     Num: 3

--- a/config/feed.yaml
+++ b/config/feed.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -22,7 +22,7 @@ Client:
     - "192.168.1.1"
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"
@@ -45,7 +45,7 @@ OSS:
   Callback: ""
 
 Redis:
-  Dest: "47.115.230.248:6379"
+  Dest: "127.0.0.1:6379"
   Password: "root"
   SendBox:
     Num: 1

--- a/config/log.yaml
+++ b/config/log.yaml
@@ -23,7 +23,11 @@ Log:
     callerEncoder: "full" # full, short
     nameEncoder: "full" # full
     consoleSeparator: " "
-
+  path: "./tmp/DouTok.log"
+  maxSize: 102400
+  maxBackups: 3
+  maxAge: 10
+  skip: 2
   outputPaths:
     - "stdout"
     - "./tmp/DouTok.log"

--- a/config/message.yaml
+++ b/config/message.yaml
@@ -3,7 +3,7 @@ Global:
   ChangeMe: "v1"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -27,7 +27,7 @@ Hbase:
   MessageNum: 50
 
 Redis:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 6379
   Password: "root"
   DataBases:

--- a/config/publish.yaml
+++ b/config/publish.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -35,7 +35,7 @@ OSS:
   Callback: ""
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"

--- a/config/relation.yaml
+++ b/config/relation.yaml
@@ -3,7 +3,7 @@ Global:
   ChangeMe: "v1"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -25,7 +25,7 @@ Hbase:
   Table: "message"
 
 Redis:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 6379
   Password: "root"
   DataBases:
@@ -45,7 +45,7 @@ Kafka:
     - "relation05"
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: "3307"
   Database: "DouTok"
   Username: "root"

--- a/config/user.yaml
+++ b/config/user.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -31,7 +31,7 @@ Snowflake:
   Node: 40
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"

--- a/config/user.yaml
+++ b/config/user.yaml
@@ -43,3 +43,6 @@ MySQL:
 Otel:
   Host: "82.156.171.8"
   Port: 4317
+
+PreventCaller:
+  - "DoutokAPIServer"

--- a/config_docker_compose/api.yaml
+++ b/config_docker_compose/api.yaml
@@ -7,7 +7,7 @@ JWT:
 
 Etcd:
   Enable: true
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -35,7 +35,7 @@ Client:
     - "192.168.1.1"
 
 Redis:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 6379
   Password: "root"
   DataBases:

--- a/config_docker_compose/comment.yaml
+++ b/config_docker_compose/comment.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -22,7 +22,7 @@ Client:
     - "192.168.1.1"
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"
@@ -38,7 +38,7 @@ HBase:
   Host: "139.9.80.79"
 
 Redis:
-  Dest: "47.115.230.248:6379"
+  Dest: "127.0.0.1:6379"
   Password: "root"
   ComCntCache:
     Num: 8

--- a/config_docker_compose/favorite.yaml
+++ b/config_docker_compose/favorite.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -25,7 +25,7 @@ Snowflake:
   Node: 602
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"
@@ -35,7 +35,7 @@ MySQL:
   loc: "Local"
 
 Redis:
-  Dest: "47.115.230.248:6379"
+  Dest: "127.0.0.1:6379"
   Password: "root"
   FavCache:
     Num: 3

--- a/config_docker_compose/feed.yaml
+++ b/config_docker_compose/feed.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -22,7 +22,7 @@ Client:
     - "192.168.1.1"
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"
@@ -45,7 +45,7 @@ OSS:
   Callback: ""
 
 Redis:
-  Dest: "47.115.230.248:6379"
+  Dest: "127.0.0.1:6379"
   Password: "root"
   SendBox:
     Num: 1

--- a/config_docker_compose/message.yaml
+++ b/config_docker_compose/message.yaml
@@ -3,7 +3,7 @@ Global:
   ChangeMe: "v1"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -27,7 +27,7 @@ Hbase:
   MessageNum: 50
 
 Redis:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 6379
   Password: "root"
   DataBases:

--- a/config_docker_compose/publish.yaml
+++ b/config_docker_compose/publish.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -35,7 +35,7 @@ OSS:
   Callback: ""
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"

--- a/config_docker_compose/relation.yaml
+++ b/config_docker_compose/relation.yaml
@@ -3,7 +3,7 @@ Global:
   ChangeMe: "v1"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -25,7 +25,7 @@ Hbase:
   Table: "message"
 
 Redis:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 6379
   Password: "root"
   DataBases:
@@ -45,7 +45,7 @@ Kafka:
     - "relation05"
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: "3307"
   Database: "DouTok"
   Username: "root"

--- a/config_docker_compose/user.yaml
+++ b/config_docker_compose/user.yaml
@@ -6,7 +6,7 @@ JWT:
   signingKey: "signingKey"
 
 Etcd:
-  Address: "47.115.230.248"
+  Address: "127.0.0.1"
   Port: 2379
 
 Server:
@@ -31,7 +31,7 @@ Snowflake:
   Node: 40
 
 MySQL:
-  Host: "47.115.230.248"
+  Host: "127.0.0.1"
   Port: 3307
   Username: "admin"
   Password: "root"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ services:
         image: registry.cn-shanghai.aliyuncs.com/doutok/api:latest
         container_name: api
         volumes:
-            -   ./config_docker_compose:/app/config
+            - ./config_docker_compose:/app/config
         networks:
             - total
         ports:
@@ -20,7 +20,7 @@ services:
         image: registry.cn-shanghai.aliyuncs.com/doutok/comment:latest
         container_name: comment
         volumes:
-            -   ./config_docker_compose:/app/config
+            - ./config_docker_compose:/app/config
         networks:
             - total
         ports:
@@ -31,7 +31,7 @@ services:
         image: registry.cn-shanghai.aliyuncs.com/doutok/favorite:latest
         container_name: favorite
         volumes:
-            -   ./config_docker_compose:/app/config
+            - ./config_docker_compose:/app/config
         networks:
             - total
         ports:
@@ -42,7 +42,7 @@ services:
         image: registry.cn-shanghai.aliyuncs.com/doutok/feed:latest
         container_name: feed
         volumes:
-            -   ./config_docker_compose:/app/config
+            - ./config_docker_compose:/app/config
         networks:
             - total
         ports:
@@ -53,7 +53,7 @@ services:
         image: registry.cn-shanghai.aliyuncs.com/doutok/message:latest
         container_name: message
         volumes:
-            -   ./config_docker_compose:/app/config
+            - ./config_docker_compose:/app/config
         networks:
             - total
         ports:
@@ -64,7 +64,7 @@ services:
         image: registry.cn-shanghai.aliyuncs.com/doutok/publish:latest
         container_name: publish
         volumes:
-            -   ./config_docker_compose:/app/config
+            - ./config_docker_compose:/app/config
         networks:
             - total
         ports:
@@ -75,7 +75,7 @@ services:
         image: registry.cn-shanghai.aliyuncs.com/doutok/relation:latest
         container_name: relation
         volumes:
-            -   ./config_docker_compose:/app/config
+            - ./config_docker_compose:/app/config
         networks:
             - total
         ports:
@@ -86,7 +86,7 @@ services:
         image: registry.cn-shanghai.aliyuncs.com/doutok/user:latest
         container_name: user
         volumes:
-            -   ./config_docker_compose:/app/config
+            - ./config_docker_compose:/app/config
         networks:
             - total
         ports:

--- a/pkg/LogBuilder/log_info_builder.go
+++ b/pkg/LogBuilder/log_info_builder.go
@@ -11,9 +11,11 @@ type LogInfoBuilder struct {
 	Items   map[string]string
 }
 
-func InitLogBuilder() *LogInfoBuilder {
+func InitLogBuilder(logType string, message string) *LogInfoBuilder {
 	return &LogInfoBuilder{
-		Items: make(map[string]string),
+		logType: logType,
+		message: message,
+		Items:   make(map[string]string),
 	}
 }
 

--- a/pkg/LogBuilder/logger.go
+++ b/pkg/LogBuilder/logger.go
@@ -1,6 +1,7 @@
 package LogBuilder
 
 import (
+	"github.com/TremblingV5/DouTok/pkg/dtviper"
 	"go.uber.org/zap"
 	"go.uber.org/zap/zapcore"
 )
@@ -14,7 +15,17 @@ type logInfo struct {
 	value string
 }
 
-func New(filename string, maxSize int, maxBackups int, maxAge int) *Logger {
+func NewByViper(config *dtviper.Config) *Logger {
+	filename := config.Viper.GetString("Log.path")
+	maxSize := config.Viper.GetInt("Log.maxSize")
+	maxBackups := config.Viper.GetInt("Log.maxBackups")
+	maxAge := config.Viper.GetInt("Log.maxAge")
+	skip := config.Viper.GetInt("Log.skip")
+
+	return New(filename, maxSize, maxBackups, maxAge, skip)
+}
+
+func New(filename string, maxSize int, maxBackups int, maxAge int, skip int) *Logger {
 	writeSyncer := getLogWriter(
 		filename, maxSize, maxBackups, maxAge,
 	)
@@ -27,7 +38,7 @@ func New(filename string, maxSize int, maxBackups int, maxAge int) *Logger {
 	}
 	core := zapcore.NewCore(encoder, writeSyncer, l)
 
-	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(1))
+	logger := zap.New(core, zap.AddCaller(), zap.AddCallerSkip(skip))
 	return &Logger{
 		Handle: logger,
 	}

--- a/pkg/initHelper/rpc_server.go
+++ b/pkg/initHelper/rpc_server.go
@@ -3,6 +3,8 @@ package initHelper
 import (
 	"context"
 	"fmt"
+	"net"
+
 	"github.com/TremblingV5/DouTok/pkg/dtviper"
 	"github.com/TremblingV5/DouTok/pkg/middleware"
 	"github.com/cloudwego/kitex/pkg/limit"
@@ -11,7 +13,6 @@ import (
 	"github.com/kitex-contrib/obs-opentelemetry/provider"
 	"github.com/kitex-contrib/obs-opentelemetry/tracing"
 	etcd "github.com/kitex-contrib/registry-etcd"
-	"net"
 )
 
 /*
@@ -35,6 +36,8 @@ func InitRPCServerArgs(config *dtviper.Config) ([]server.Option, func()) {
 		provider.WithExportEndpoint(fmt.Sprintf("%s:%s", config.Viper.GetString("Otel.Host"), config.Viper.GetString("Otel.Port"))),
 		provider.WithInsecure(),
 	)
+
+	preventedCaller := config.Viper.GetStringSlice("PreventCaller")
 
 	return []server.Option{
 			server.WithServiceAddr(serverAddr),

--- a/pkg/initHelper/rpc_server.go
+++ b/pkg/initHelper/rpc_server.go
@@ -40,6 +40,7 @@ func InitRPCServerArgs(config *dtviper.Config) ([]server.Option, func()) {
 			server.WithServiceAddr(serverAddr),
 			server.WithMiddleware(middleware.CommonMiddleware),
 			server.WithMiddleware(middleware.ServerMiddleware),
+			server.WithMiddleware(middleware.GetKitexStreamingCallPreventMiddleware([]string{"api", "comment", "relation"})),
 			server.WithRegistry(registry),
 			server.WithLimit(&limit.Option{MaxConnections: 1000, MaxQPS: 100}), // limit
 			server.WithMuxTransport(),

--- a/pkg/middleware/streaming_call.go
+++ b/pkg/middleware/streaming_call.go
@@ -1,0 +1,23 @@
+package middleware
+
+import (
+	"fmt"
+	"github.com/cloudwego/kitex/pkg/acl"
+	"github.com/cloudwego/kitex/pkg/endpoint"
+	"golang.org/x/net/context"
+)
+
+/*
+	初始化Kitex中间件，以防止不规范的循环调用出现。
+	preventList中包括若干服务名，凡是出现在该List中的所有服务对使用该中间件的服务的调用均会被直接拒绝
+*/
+func GetKitexStreamingCallPreventMiddleware(preventList []string) endpoint.Middleware {
+	return acl.NewACLMiddleware(
+		[]acl.RejectFunc{
+			func(ctx context.Context, request interface{}) error {
+				fmt.Println(request)
+				return nil
+			},
+		},
+	)
+}

--- a/pkg/middleware/streaming_call.go
+++ b/pkg/middleware/streaming_call.go
@@ -2,6 +2,7 @@ package middleware
 
 import (
 	"fmt"
+
 	"github.com/cloudwego/kitex/pkg/acl"
 	"github.com/cloudwego/kitex/pkg/endpoint"
 	"golang.org/x/net/context"


### PR DESCRIPTION
# 概述

1. 针对Kitex微服务添加一个请求拦截中间件，阻止来自提供的服务的任何请求
2. 在api和user模块添加了相关的代码进行测试
3. 在api模块的rpc/user.go添加了调用LogBuilder的代码
4. 更新以提升LogBuilder的初始化和实际使用

## 关于使用拒绝指定模块调用的中间件如何使用

通过配置文件进行使用，参考`config/user.yml`中的配置，加载中间件的操作已经集成到了`initHelper/rpc_server.go`中